### PR TITLE
Add task add command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/tasks/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tasks/AddTaskCommand.java
@@ -1,0 +1,61 @@
+package seedu.address.logic.commands.tasks;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.task.Task;
+
+/**
+ * Command to add a new Task
+ */
+public class AddTaskCommand extends TaskCommand {
+
+    public static final String COMMAND_WORD = "add";
+
+    public static final String MESSAGE_USAGE =
+            TaskCommand.COMMAND_WORD + " " + COMMAND_WORD + ": Adds a task to the address book. " + "Parameters: "
+                    + PREFIX_TITLE + "TITLE " + PREFIX_GROUP + "GROUP " + "[" + PREFIX_STATUS + "STATUS]...\n"
+                    + "Example: " + COMMAND_WORD + " " + PREFIX_TITLE + "Write v1 Documentation " + PREFIX_GROUP
+                    + "My Group " + PREFIX_STATUS + "Completed";
+
+    public static final String MESSAGE_SUCCESS = "New task added: %1$s";
+    public static final String MESSAGE_DUPLICATE_TASK = "This task already exists in the address book";
+
+    public static final String MESSAGE_MISSING_GROUP = "This group does not exist in the address book";
+
+    private final Task toAdd;
+
+    /**
+     * Creates an AddCommand to add the specified {@code Task}
+     */
+    public AddTaskCommand(Task task) {
+        requireNonNull(task);
+        toAdd = task;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.hasTeam(toAdd.getParentGroup())) {
+            throw new CommandException(MESSAGE_MISSING_GROUP);
+        } else if (model.hasTask(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_TASK);
+        }
+
+        model.addTask(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddTaskCommand // instanceof handles nulls
+                && toAdd.equals(((AddTaskCommand) other).toAdd));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/tasks/TaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tasks/TaskCommand.java
@@ -1,0 +1,10 @@
+package seedu.address.logic.commands.tasks;
+
+import seedu.address.logic.commands.Command;
+
+/**
+ * Base command for all Task commands
+ */
+public abstract class TaskCommand extends Command {
+    public static final String COMMAND_WORD = "task";
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,7 +15,9 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.tasks.TaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.tasks.TaskCommandParser;
 
 /**
  * Parses user input.
@@ -67,6 +69,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case TaskCommand.COMMAND_WORD:
+            return new TaskCommandParser().parseCommand(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-
+    public static final Prefix PREFIX_TITLE = new Prefix("t/");
+    public static final Prefix PREFIX_GROUP = new Prefix("g/");
+    public static final Prefix PREFIX_STATUS = new Prefix("s/");
 }

--- a/src/main/java/seedu/address/logic/parser/tasks/AddTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tasks/AddTaskCommandParser.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.parser.tasks;
+
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.tasks.AddTaskCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.group.Group;
+import seedu.address.model.task.Task;
+
+/**
+ * Parses input arguments and creates a new AddCommand object
+ */
+public class AddTaskCommandParser implements Parser<AddTaskCommand> {
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand and returns an AddCommand object
+     * for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddTaskCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_GROUP, PREFIX_STATUS);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_TITLE, PREFIX_GROUP, PREFIX_STATUS) || !argMultimap.getPreamble()
+                .isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTaskCommand.MESSAGE_USAGE));
+        }
+
+        String title = argMultimap.getValue(PREFIX_TITLE).get().trim();
+        String status = argMultimap.getValue(PREFIX_STATUS).get().trim();
+        String groupName = argMultimap.getValue(PREFIX_GROUP).get().trim();
+
+        Task task = new Task(title, status, new Group(groupName));
+
+        return new AddTaskCommand(task);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/tasks/TaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tasks/TaskCommandParser.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.parser.tasks;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.tasks.AddTaskCommand;
+import seedu.address.logic.commands.tasks.TaskCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parser for all Task commands
+ */
+public class TaskCommandParser {
+    /**
+     * Used for initial separation of command word and args.
+     */
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+
+    /**
+     * Parses user input into command for execution.
+     *
+     * @param userInput full user input string
+     * @return the command based on the user input
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public TaskCommand parseCommand(String userInput) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String commandWord = matcher.group("commandWord");
+        final String arguments = matcher.group("arguments");
+        switch (commandWord) {
+
+        case AddTaskCommand.COMMAND_WORD:
+            return new seedu.address.logic.parser.tasks.AddTaskCommandParser().parse(arguments);
+
+        default:
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -15,11 +15,22 @@ public class Group extends AbstractContainerItem {
     private final Group parent;
     private final UniqueTaskList taskList;
 
-    Group(String groupName) {
+    /**
+     * Create a new group with given name.
+     *
+     * @param groupName The name of the group
+     */
+    public Group(String groupName) {
         this(groupName, null);
     }
 
-    Group(String groupName, Group parent) {
+    /**
+     * Create a new group with given name and parent.
+     *
+     * @param groupName The name of the group
+     * @param parent The parent of the group
+     */
+    public Group(String groupName, Group parent) {
         this.groupName = groupName;
         this.parent = parent;
         taskList = new UniqueTaskList();
@@ -27,6 +38,7 @@ public class Group extends AbstractContainerItem {
 
     /**
      * Checks if a task exists in this group
+     *
      * @param task The task to check if exists
      * @return true if it exists in this Group, false otherwise
      */
@@ -45,6 +57,7 @@ public class Group extends AbstractContainerItem {
 
     /**
      * Removes a task from this group. The task must already exist in this group
+     *
      * @param task The task to remove
      */
     public void removeTask(Task task) {

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -23,9 +23,10 @@ public class Task implements DisplayItem {
      *
      * @param title The title of the task.
      * @param status The status of the task.
+     * @param group The group the task belongs to.
      */
-    public Task(String title, String status) {
-        this(title, status, null);
+    public Task(String title, String status, Group group) {
+        this(title, status, group, null);
     }
 
     /**
@@ -33,11 +34,13 @@ public class Task implements DisplayItem {
      *
      * @param title The title of the task.
      * @param status The status of the task.
+     * @param group The group of the task.
      * @param completedTime The completed_time of the task.
      */
-    public Task(String title, String status, LocalDateTime completedTime) {
+    public Task(String title, String status, Group group, LocalDateTime completedTime) {
         this.title = title;
         this.status = status;
+        this.parent = group;
         this.completedTime = completedTime;
     }
 
@@ -111,5 +114,11 @@ public class Task implements DisplayItem {
     @Override
     public boolean isPartOfContext(DisplayItem o) {
         return parent.equals(o);
+    }
+
+    @Override
+    public String toString() {
+        return "Task{" + "title: '" + title + '\'' + "; status: '" + status + '\'' + "; completedTime: " + completedTime
+                + "; parent: " + parent + '}';
     }
 }


### PR DESCRIPTION
Fixes #34 

The app currently does not support adding new tasks.

This commit adds the ability to add new tasks with the following command format as copied from the user guide:
`task add t/<TITLE> g/<GROUP> [s/<STATUS>]`

Currently untested as adding Groups has not been implemented yet.