### PR TITLE
Fix sample data crashes

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -19,7 +19,7 @@ import seedu.address.model.item.exceptions.ItemCannotBeParentException;
  * Represents a Person in the address book. Guarantees: details are present and not null, field
  * values are validated, immutable.
  */
-public class Person extends AbstractDisplayItem {
+public class Person extends AbstractSingleItem {
 
     private Set<AbstractSingleItem> parents = new HashSet<>();
 

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String VALIDATION_REGEX = "[a-zA-Z0-9_\\-][a-zA-Z0-9_\\- ]*";
 
     public final String tagName;
 

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -176,12 +176,13 @@ public class Task extends AbstractSingleItem {
             throw new ItemCannotBeParentException(o);
         }
 
-        if (o instanceof AbstractSingleItem) {
-            setParentForSingleGrp((AbstractSingleItem) o);
-        }
-
         if (o instanceof Person) {
             setContactParent((Person) o);
+            return;
+        }
+
+        if (o instanceof AbstractSingleItem) {
+            setParentForSingleGrp((AbstractSingleItem) o);
         }
 
     }
@@ -199,7 +200,7 @@ public class Task extends AbstractSingleItem {
         if (o == null) {
             return;
         }
-        if (!assignedParents.contains(o)) {
+        if (assignedParents.contains(o)) {
             throw new ItemCannotBeParentException(o);
         }
 


### PR DESCRIPTION
Fix crashes caused by updated sample data from #157.

The issue was due to the setting of unorthodox parents (Person parent of Person, Person parent of Task). This PR allows for that to happen so that the sample data can work.