### PR TITLE
Rename all instances of ContactMation to Contactmation

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -419,16 +419,16 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 ### Use cases
 
-(For all use cases below, the **System** is `ContactMation` and the **Actor** is the `user`, unless specified otherwise)
+(For all use cases below, the **System** is `Contactmation` and the **Actor** is the `user`, unless specified otherwise)
 
 **Use case: UC01 - Delete a person**
 
 **MSS**
 
 1.  User requests to list persons.
-2.  ContactMation shows a list of persons.
+2.  Contactmation shows a list of persons.
 3.  User requests to delete a specific person in the list.
-4.  ContactMation deletes the person.
+4.  Contactmation deletes the person.
 
     Use case ends.
 
@@ -440,7 +440,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 - 3a. The given index is invalid.
 
-  - 3a1. ContactMation shows an error message.
+  - 3a1. Contactmation shows an error message.
 
     Use case resumes at step 2.
 
@@ -449,9 +449,9 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 
 1.  User requests to list persons.
-2.  ContactMation shows a list of persons.
+2.  Contactmation shows a list of persons.
 3.  User requests to edit a specific person in the list.
-4.  ContactMation shows a screen with the properties of the person.
+4.  Contactmation shows a screen with the properties of the person.
 5.  User edits the properties to their liking and saves.
 6.  Contactmation saves the data.
 
@@ -465,7 +465,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 - 3a. The given index is invalid.
 
-  - 3a1. ContactMation shows an error message.
+  - 3a1. Contactmation shows an error message.
 
     Use case resumes at step 2.
 
@@ -474,7 +474,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 
 1.  User requests to create a team with a team name.
-2.  ContactMation creates the team.
+2.  Contactmation creates the team.
 
     Use case ends.
 
@@ -482,13 +482,13 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 - 1a. The team name is empty or invalid.
 
-    - 1a1. ContactMation shows an error message. 
+    - 1a1. Contactmation shows an error message. 
 
       Use case ends.
 
 - 2a. The new team is in the current path.
 
-    - 2a1. ContactMation adds the new team to the list of teams in this path.
+    - 2a1. Contactmation adds the new team to the list of teams in this path.
 
       Use case ends.
 
@@ -496,10 +496,10 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 **MSS**
 
-1.  ContactMation shows a list of teams.
+1.  Contactmation shows a list of teams.
 2.  User requests to enter a team context.
-3.  ContactMation enters the team context.
-4.  ContactMation only shows information specified to the new team context.
+3.  Contactmation enters the team context.
+4.  Contactmation only shows information specified to the new team context.
 
     Use case ends.
 
@@ -507,7 +507,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 - 2a. The team selected is invalid.
 
-    - 2a1. ContactMation shows an error message.
+    - 2a1. Contactmation shows an error message.
 
       Use case ends.
 
@@ -516,9 +516,9 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 
 1.  User requests to list groups.
-2.  ContactMation shows a list of groups.
+2.  Contactmation shows a list of groups.
 3.  User requests to add a task to a group in the list.
-4.  ContactMation adds the task.
+4.  Contactmation adds the task.
 
     Use case ends.
 
@@ -530,7 +530,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 - 3a. The given index is invalid.
 
-  - 3a1. ContactMation shows an error message.
+  - 3a1. Contactmation shows an error message.
 
     Use case resumes at step 2.
 
@@ -539,9 +539,9 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 
 1.  User requests to list tasks for a group.
-2.  ContactMation shows a list of tasks.
+2.  Contactmation shows a list of tasks.
 3.  User requests to set the task completion status.
-4.  ContactMation sets the task completion status.
+4.  Contactmation sets the task completion status.
 
     Use case ends.
 
@@ -553,13 +553,13 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 - 3a. The given index is invalid.
 
-  - 3a1. ContactMation shows an error message.
+  - 3a1. Contactmation shows an error message.
 
     Use case resumes at step 2.
 
 - 4a. The given status is empty.
 
-  - 4a1. ContactMation sets the task to `Done`
+  - 4a1. Contactmation sets the task to `Done`
 
     Use case ends.
 
@@ -568,7 +568,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 
 1.  User enters the command to create a macro.
-2.  ContactMation creates and saves the macro.
+2.  Contactmation creates and saves the macro.
 
     Use case ends.
 
@@ -576,7 +576,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 - 1a. The macro command is invalid.
 
-    - 1a1. ContactMation shows an error message.
+    - 1a1. Contactmation shows an error message.
 
       Use case ends.
 
@@ -585,7 +585,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 
 1.  User requests to use a macro.
-2.  ContactMation executes the commands defined by the macro.
+2.  Contactmation executes the commands defined by the macro.
 
     Use case ends.
 
@@ -593,7 +593,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 - 1a. The macro does not exist.
 
-    - 2a1. ContactMation shows an error message.
+    - 2a1. Contactmation shows an error message.
 
       Use case ends.
 
@@ -603,7 +603,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 
 1.  User requests to use a with a supplied command over selected item type.
-2.  ContactMation executes the command over the selected item type.
+2.  Contactmation executes the command over the selected item type.
 
     Use case ends.
 
@@ -611,20 +611,20 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 - 1a. The command is invalid.
 
-    - 1a1. ContactMation shows an error message.
+    - 1a1. Contactmation shows an error message.
 
       Use case ends.
     
 - 1b. The selected item type does not exist.
 
-    - 1b1. ContactMation shows an error message.
+    - 1b1. Contactmation shows an error message.
 
       Use case ends.
 
 - 2a. The command fails on an item.
 
-  - 2a1. ContactMation stops execution of the loop.
-  - 2a2. ContactMation displays an error message
+  - 2a1. Contactmation stops execution of the loop.
+  - 2a2. Contactmation displays an error message
     
     Use case ends.
 
@@ -641,7 +641,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 - 2a. The macro does not exist.
 
-    - 2a1. ContactMation shows an error message.
+    - 2a1. Contactmation shows an error message.
 
       Use case ends.
 


### PR DESCRIPTION
Fixes the developer guide using ContactMation instead of Contactmation.